### PR TITLE
Rel1 44

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -40,7 +40,7 @@
 			"aspaklarya-lockdown-list": true,
 			"aspaklarya-lock-revisions": true
 		},
-		"spiritualCommittee": {
+		"spiritual-committee": {
 			"aspaklarya-read-locked": true,
 			"aspaklarya-read-semi-locked": true,
 			"aspaklarya-edit-locked": true,

--- a/extension.json
+++ b/extension.json
@@ -19,7 +19,7 @@
 		"MediaWiki\\Extension\\AspaklaryaLockDown\\": "includes/"
 	},
 	"GroupPermissions": {
-		"aspaklaryaEditor": {
+		"aspaklarya-editor": {
 			"aspaklarya-read-locked": true,
 			"aspaklarya-read-semi-locked": true,
 			"aspaklarya-edit-locked": true,


### PR DESCRIPTION
This pull request includes changes to the `extension.json` file to standardize group permission keys by converting them to kebab-case. 

### Standardization of group permission keys:
* Changed the group key `aspaklaryaEditor` to `aspaklarya-editor` to follow kebab-case naming conventions. (`extension.json`, [extension.jsonL22-R22](diffhunk://#diff-6a6295f752062fb0eec4a9df4e87c164b8d8d3b48023a54a1e682671296eb8a3L22-R22))
* Changed the group key `spiritualCommittee` to `spiritual-committee` to follow kebab-case naming conventions. (`extension.json`, [extension.jsonL43-R43](diffhunk://#diff-6a6295f752062fb0eec4a9df4e87c164b8d8d3b48023a54a1e682671296eb8a3L43-R43))